### PR TITLE
Skip reading section data if the section doesn't contain any table.

### DIFF
--- a/src/do_md.c
+++ b/src/do_md.c
@@ -99,7 +99,7 @@ int is_prelinked(int fd) {
         while (!bingo && (scn = elf_nextscn(elf, scn)) != NULL) {
                 (void) gelf_getshdr(scn, &shdr);
 
-                if (shdr.sh_type != SHT_DYNAMIC)
+                if (shdr.sh_type != SHT_DYNAMIC || shdr.sh_entsize == 0)
                         continue;
 
                 while (!bingo && (data = elf_getdata (scn, data)) != NULL) {


### PR DESCRIPTION
Fixes floating point exception on go files reported in https://sourceforge.net/p/aide/bugs/101/

shdr.sh_entsize indeed is not changed by the elf_getdata. However, I'm not an expert on the ELF format, so I can't guarantee that a non-table section can never be DT_GNU_PRELINKED or DT_GNU_LIBLIST.