### PR TITLE
patch for selected warnings on src/commandconf.c and src/compare_db.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+*.c_orig
+*.c~
+*.patch

--- a/src/commandconf.c
+++ b/src/commandconf.c
@@ -650,8 +650,8 @@ int handle_endif(int doit,int allow_else){
       
       case 0 : {
 	conferror("@@endif or @@else expected");
-	return -1;
 	count=0;
+   return -1;
       }
       
       default : {

--- a/src/commandconf.c
+++ b/src/commandconf.c
@@ -651,7 +651,7 @@ int handle_endif(int doit,int allow_else){
       case 0 : {
 	conferror("@@endif or @@else expected");
 	count=0;
-   return -1;
+        return -1;
       }
       
       default : {

--- a/src/compare_db.c
+++ b/src/compare_db.c
@@ -414,17 +414,17 @@ snprintf(*values[0], l, "%s",s);
             easy_string(get_file_type_string(line->perm))
         } else if (DB_LINKNAME&attr) {
             easy_string(line->linkname)
-        easy_number((DB_SIZE|DB_SIZEG),size,"%li")
+        easy_number((DB_SIZE|DB_SIZEG),size,"%lli")
         } else if (DB_PERM&attr) {
             *values[0] = perm_to_char(line->perm);
         easy_time(DB_ATIME,atime)
         easy_time(DB_MTIME,mtime)
         easy_time(DB_CTIME,ctime)
-        easy_number(DB_BCOUNT,bcount,"%li")
+        easy_number(DB_BCOUNT,bcount,"%lli")
         easy_number(DB_UID,uid,"%i")
         easy_number(DB_GID,gid,"%i")
-        easy_number(DB_INODE,inode,"%lu")
-        easy_number(DB_LNKCOUNT,nlink,"%lu")
+        easy_number(DB_INODE,inode,"%llu")
+        easy_number(DB_LNKCOUNT,nlink,"%hu")
         easy_md(DB_MD5,md5,HASH_MD5_LEN)
         easy_md(DB_SHA1,sha1,HASH_SHA1_LEN)
         easy_md(DB_RMD160,rmd160,HASH_RMD160_LEN)


### PR DESCRIPTION
```
src/commandconf.c:228:7: warning: unused variable 'err' [-Wunused-variable]
  int err=0;
      ^

src/commandconf.c:654:8: warning: code will never be executed [-Wunreachable-code]
        count=0;
              ^

src/compare_db.c:417:9: warning: format specifies type 'long' but the argument has type 'off_t' (aka 'long long') [-Wformat]
        easy_number((DB_SIZE|DB_SIZEG),size,"%li")
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                             %lli
src/compare_db.c:392:31: note: expanded from macro 'easy_number'
    snprintf(*values[0], l, c,line->b);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~


src/compare_db.c:423:9: warning: format specifies type 'long' but the argument has type 'blkcnt_t' (aka 'long long') [-Wformat]
        easy_number(DB_BCOUNT,bcount,"%li")
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                      %lli
src/compare_db.c:392:31: note: expanded from macro 'easy_number'
    snprintf(*values[0], l, c,line->b);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~

src/compare_db.c:426:9: warning: format specifies type 'unsigned long' but the argument has type 'ino_t' (aka 'unsigned long long') [-Wformat]
        easy_number(DB_INODE,inode,"%lu")
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    %llu
src/compare_db.c:392:31: note: expanded from macro 'easy_number'
    snprintf(*values[0], l, c,line->b);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~


src/compare_db.c:427:9: warning: format specifies type 'unsigned long' but the argument has type 'nlink_t' (aka 'unsigned short') [-Wformat]
        easy_number(DB_LNKCOUNT,nlink,"%lu")
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                       %hu
src/compare_db.c:392:31: note: expanded from macro 'easy_number'
    snprintf(*values[0], l, c,line->b);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~

```