### PR TITLE
Extended attributes support (fix)

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@
     written to be a simple and free alternative to Tripwire. Features
     currently included in AIDE are as follows:
 
-        o  File attributes monitored: perissions, inode, user, group
+        o  File attributes monitored: permissions, inode, user, group
            file size, mtime, atime, ctime, links and growing size.
         o  Checksums and hashes supported: SHA1, MD5, RMD160, and TIGER.
            CRC32, HAVAL and GOST if Mhash support is compiled in.

--- a/src/do_md.c
+++ b/src/do_md.c
@@ -607,7 +607,8 @@ void xattrs2line(db_line *line) {
             ssize_t aret = 0;
 
             if (strncmp(attr, "user.", strlen("user.")) &&
-                    strncmp(attr, "root.", strlen("root.")))
+                    strncmp(attr, "security.", strlen("security.")) &&
+                    strncmp(attr, "trusted.", strlen("trusted.")))
                 goto next_attr; /* only store normal xattrs, and SELinux */
 
             while (((aret = getxattr(line->fullpath, attr, val, asz)) ==


### PR DESCRIPTION
Hi,

I noticed that Aide was not able to detect file capabilities modifications (for example set with: `setcap CAP_DAC_OVERRIDE+ep <file>`). This is because it didn't properly check the "_security_" namespace of the extended attribute (where the file capabilities and the SELinux attributes are stored). I also find useful to retrieve other namespaces that may be set from userland (ie. "_user.*_" and "_trusted.*_").

To finish I removed the check on the "_root.*_" namespace since it does not seem to exist [1][2].

Julien.

  [1] https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/xattr.h
  [2] https://linux.die.net/man/5/attr
