### PR TITLE
Fix typos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-If you have any questions about aide, it's use or applications please send
+If you have any questions about aide, its use or applications please send
 your inquiries to the mailing list at aide@ipi.fi rather than to the
 individuals named below.
 

--- a/doc/aide.1.in
+++ b/doc/aide.1.in
@@ -63,7 +63,7 @@ Controls how verbose \fBaide\fP is. Value must [0-255]. The default is
 5. With no argument Value is set to 20. This parameter overrides the
 value set in a configuration file.
 .IP "--report=\fBreporter\fR,-r \fBreporter\fR"
-\fBreporter\fR is a URL which tells \fBaide\fP where to send it's
+\fBreporter\fR is a URL which tells \fBaide\fP where to send its
 output. See aide.conf (5) section URLS for available values.
 .IP "--version,-v"
 \fBaide\fP prints out its version number

--- a/doc/aide.conf.in
+++ b/doc/aide.conf.in
@@ -130,7 +130,7 @@ Norm=l+s+n+b+md5+sha1+rmd160+sha256+sha512+tiger@aideextragroups@
 
 #Selection regexp rule
 @@{TOPDIR}/.* Norm
-#Equals selection only the directory doc is checked and not it's children
+#Equals selection only the directory doc is checked and not its children
 #=@@{TOPDIR}/doc L
 #Negative selection no rule is necessary but ignored if there
 !@@{TOPDIR}/.*~

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -61,7 +61,7 @@ explicitly enabled during compile time.
 </p><p>
 Typically, a system administrator will create an AIDE database on a
 new system before it is brought onto the network. This first AIDE
-database is a snapshot of the system in it's normal state and the
+database is a snapshot of the system in its normal state and the
 yardstick by which all subsequent updates and changes will be
 measured. The database should contain information about key system
 binaries, libraries, header files, all files
@@ -308,7 +308,7 @@ that are always printed from changed files. For example, if you say
 report_force_attrs = u+g
 </pre>
 <p>
-and the size of a file changes, it's user and group id will also be printed
+and the size of a file changes, its user and group id will also be printed
 in the report. Secondly, report_ignore_added_attrs,
 report_ignore_removed_attrs and report_ignore_changed_attrs define which
 attributes to ignore from the report. For example, if you define
@@ -317,7 +317,7 @@ attributes to ignore from the report. For example, if you define
 report_ignore_changed_attrs = b
 </pre>
 <p>
-and the size of a file changes, it's block count will not be printed in the
+and the size of a file changes, its block count will not be printed in the
 report, even if it did change as well.
 </p>
 <p>

--- a/src/md.c
+++ b/src/md.c
@@ -160,7 +160,7 @@ DB_ATTR_TYPE hash_mhash2attr(int i) {
 }
 
 /*
-  Initialise md_container according it's todo_attr field
+  Initialise md_container according its todo_attr field
  */
 
 int init_md(struct md_container* md) {


### PR DESCRIPTION
I've noticed an "it's" vs "its" typo in the `AUTHORS` file recently, so I decided to send a quick PR about it. Based on git and PR history, I also noticed #63, which was about fixing the same thing elsewhere. It looks like it was a common typo throughout the various files, so I tried to fix all cases I could find.

Let me know if you need me to update this commit in any way.