### PR TITLE
fix #104 util.h ignored config.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-11-14 Jason Pyeron <jpyeron@pdinc.us>
+	* Add missing config.h include (closes: #104)
+
 2021-11-07 Hannes von Haugwitz <hannes@vonhaugwitz.com>
 	* Remove bashism in configure.ac
 

--- a/include/util.h
+++ b/include/util.h
@@ -21,6 +21,7 @@
 
 #ifndef _UTIL_H_INCLUDED
 #define _UTIL_H_INCLUDED
+#include "config.h"
 #include <string.h>
 #include <stdbool.h>
 #include <sys/types.h>


### PR DESCRIPTION
simple fix, now builds on cygwin too when --disable-static is used