### PR TITLE
Enable gcrypt MD5 hashsum only if not in fips mode

### DIFF
--- a/src/hashsum.c
+++ b/src/hashsum.c
@@ -88,6 +88,11 @@ DB_ATTR_TYPE get_hashes(bool include_unsupported) {
     DB_ATTR_TYPE attr = 0LLU;
     for (int i = 0; i < num_hashes; ++i) {
         if (include_unsupported || algorithms[i] >= 0) {
+#ifdef WITH_GCRYPT
+            /* Skip MD5 with gcrypt in fips_mode */
+            if (gcry_fips_mode_active() && algorithms[i] == GCRY_MD_MD5)
+                continue;
+#endif
             attr |= ATTR(hashsums[i].attribute);
         }
     }


### PR DESCRIPTION
Add check for fips mode, and enable gcrypt MD5 hashsum only if it is not
active. Otherwise, md5_init in gcrypt cipher/md5.c will fatally abort with

"Every time you use MD5 god kills a kitten. How many more have to die?"