### PR TITLE
Fix wrong format specifier

### DIFF
--- a/src/conf_eval.c
+++ b/src/conf_eval.c
@@ -486,7 +486,7 @@ static void include_file(const char* file, bool execute, int include_depth, char
                 while (child_stderr && *child_stderr != '\0') {
                     newline = strchr(child_stderr, '\n');
                     if (newline != NULL) {
-                        log_msg(LOG_LEVEL_ERROR, "%s: stderr> %.*s", file, newline-child_stderr, child_stderr);
+                        log_msg(LOG_LEVEL_ERROR, "%s: stderr> %.*s", file, (int)(newline-child_stderr), child_stderr);
                         child_stderr = newline+1;
                     } else {
                         log_msg(LOG_LEVEL_ERROR, "%s: stderr> %s", file, child_stderr);

--- a/src/db.c
+++ b/src/db.c
@@ -246,7 +246,7 @@ db_line* db_char2line(char** ss, database* db){
 
   for(int i=0;i<db->num_fields;i++){
 
-    log_msg(LOG_LEVEL_TRACE, "db_char2line(): %d[%d]: '%s' (%p)", db->lineno, i, ss[i], ss[i]);
+    log_msg(LOG_LEVEL_TRACE, "db_char2line(): %ld[%d]: '%s' (%p)", db->lineno, i, ss[i], ss[i]);
 
     switch (db->fields[i]) {
     case attr_filename : {

--- a/src/md.c
+++ b/src/md.c
@@ -102,7 +102,7 @@ int init_md(struct md_container* md, const char *filename) {
  */
 
 int update_md(struct md_container* md,void* data,ssize_t size) {
-  log_msg(LOG_LEVEL_TRACE,"update_md(md=%p, data=%p, size=%i)", md, data, size);
+  log_msg(LOG_LEVEL_TRACE,"update_md(md=%p, data=%p, size=%zi)", md, data, size);
 
 #ifdef _PARAMETER_CHECK_
   if (md==NULL||data==NULL) {


### PR DESCRIPTION
Calling a printf-like function with the wrong type of arguments causes unpredictable behavior.