### PR TITLE
fix grammar of a/an in aide.conf.5

### DIFF
--- a/doc/aide.conf.5
+++ b/doc/aide.conf.5
@@ -311,27 +311,27 @@ The attribute that is associated with each letter is as follows:
 
 .RS
 .IP o
-A \fBl\fP means that the link name has changed.
+An \fBl\fP means that the link name has changed.
 .IP o
 A \fBb\fP means that the block count has changed.
 .IP o
 A \fBp\fP means that the permissions have changed.
 .IP o
-An \fBu\fP means that the uid has changed.
+A \fBu\fP means that the uid has changed.
 .IP o
 A \fBg\fP means that the gid has changed.
 .IP o
 An \fBa\fP means that the access time has changed.
 .IP o
-A \fBm\fP means that the modification time has changed.
+An \fBm\fP means that the modification time has changed.
 .IP o
 A \fBc\fP means that the change time has changed.
 .IP o
 An \fBi\fP means that the inode has changed.
 .IP o
-A \fBn\fP means that the link count has changed.
+An \fBn\fP means that the link count has changed.
 .IP o
-A \fBH\fP means that one or more message digests have changed.
+An \fBH\fP means that one or more message digests have changed.
 .RE
 
 .RS
@@ -340,13 +340,13 @@ The following letters are only available when explicitly enabled using configure
 
 .RS
 .IP o
-A \fBA\fP means that the access control list has changed.
+An \fBA\fP means that the access control list has changed.
 .IP o
-A \fBX\fP means that the extended attributes have changed.
+An \fBX\fP means that the extended attributes have changed.
 .IP o
-A \fBS\fP means that the SELinux attributes have changed.
+An \fBS\fP means that the SELinux attributes have changed.
 .IP o
-A \fBE\fP means that the file attributes on a second extended file system have changed.
+An \fBE\fP means that the file attributes on a second extended file system have changed.
 .IP o
 A \fBC\fP means that the file capabilities have changed.
 .RE


### PR DESCRIPTION
When using A or an in front of a letter, an should be used if the phonetic pronunciation of the letter starts with a vowel.

e.g
- a 'u' is grammatically correct because 'u' is pronounced 'yoo'
- an 'h' is grammatically correct because 'h' is prononched 'aych'