### PR TITLE
allow version.sh to accept GIT_VERSION from environment

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2024-07-08 Marc 'Zugschlus' Haber <mh+github@zugschlus.de>
+	* Allow version.sh to accept GIT_VERSION from environment
+
 2024-06-16 Hannes von Haugwitz <hannes@vonhaugwitz.com>
 	* Add non-recursive negative rules (-<regex>)
 	  - change semantic of unrestricted (recursive) negative rules

--- a/version.sh
+++ b/version.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-if GIT_VERSION=$(git describe --always); then
-    echo "m4_define([AIDE_VERSION], [${GIT_VERSION#v}])" > version.m4.$$
-    mv version.m4.$$ version.m4
-    rm -f version.m4.$$
-else
-    echo "Error: 'git describe --always' failed"
-    exit 1
+if [ -z "$GIT_VERSION" ]; then
+    if ! GIT_VERSION=$(git describe --always); then
+        echo "Error: 'git describe --always' failed"
+        exit 1
+    fi
 fi
+
+echo "m4_define([AIDE_VERSION], [${GIT_VERSION#v}])" > version.m4.$$
+mv version.m4.$$ version.m4
+rm -f version.m4.$$


### PR DESCRIPTION
This makes it easier to package development snapshots with a defined version number