### PR TITLE
 Add support for digest using GnuTLS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
           fi
         env:
           CC: ${{ matrix.compiler }}
-          CFLAGS: -Werror -Wall -pedantic -g
+          CFLAGS: -Werror -Wall -pedantic -g -Wno-misleading-indentation
       - name: make
         run: make
       - name: make check

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,20 +12,33 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         compiler: [gcc, clang]
+        crypto: [nettle-dev, libgnutls28-dev, libgcrypt-dev]
 
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt install autoconf-archive bison flex nettle-dev libpcre2-dev zlib1g-dev check
+        run: sudo apt install make pkg-config autoconf-archive bison flex libpcre2-dev zlib1g-dev check ${{ matrix.crypto }}
       - name: autoconf
         run: ./autogen.sh
       - name: configure
-        run: ./configure
+        run: |
+          if [ "${{ matrix.crypto }}" = "libgnutls28-dev" ]; then
+            ./configure --without-nettle --without-gcrypt
+          else
+            ./configure --without-gnutls
+          fi
         env:
           CC: ${{ matrix.compiler }}
+          CFLAGS: -Werror -Wall -pedantic -g
       - name: make
         run: make
       - name: make check
         run: make check
       - name: make distcheck
-        run: make distcheck
+        run: |
+          if [ "${{ matrix.crypto }}" = "libgnutls28-dev" ]; then
+            export DISTCHECK_CONFIGURE_FLAGS="--without-nettle --without-gcrypt"
+          else
+            export DISTCHECK_CONFIGURE_FLAGS="--without-gnutls"
+          fi
+          make distcheck

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,17 +12,23 @@ jobs:
       matrix:
         os: [macos-latest]
         compiler: [gcc, clang]
+        crypto: [gnutls, nettle, libgcrypt]
 
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: brew install autoconf autoconf-archive automake bison pkg-config libgcrypt libgpg-error pcre2 check
+        run: brew install autoconf autoconf-archive automake bison pkg-config ${{ matrix.crypto }} pcre check
       - name: update path
         run: echo /opt/homebrew/opt/bison/bin >> ${GITHUB_PATH}
       - name: autoconf
         run: ./autogen.sh
       - name: configure
-        run: ./configure
+        run: |
+          if [ "${{ matrix.crypto }}" = "gnutls" ]; then
+            ./configure --without-nettle --without-gcrypt
+          else
+            ./configure --without-gnutls
+          fi
         env:
           CC: ${{ matrix.compiler }}
       - name: make
@@ -30,4 +36,10 @@ jobs:
       - name: make check
         run: make check
       - name: make distcheck
-        run: make distcheck
+        run: |
+          if [ "${{ matrix.crypto }}" = "gnutls" ]; then
+            export DISTCHECK_CONFIGURE_FLAGS="--without-nettle --without-gcrypt"
+          else
+            export DISTCHECK_CONFIGURE_FLAGS="--without-gnutls"
+          fi
+          make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,6 +74,7 @@ aide_CFLAGS = @AIDE_DEFS@ -I$(top_srcdir)/include -W -Wall -g \
 			${ELF_CFLAGS} \
 			${GCRYPT_CFLAGS} \
 			${NETTLE_CFLAGS} \
+			${GNUTLS_CFLAGS} \
 			${PCRE2_CFLAGS} \
 			${POSIX_ACL_CFLAGS} \
 			${PTHREAD_CFLAGS} \
@@ -88,6 +89,7 @@ aide_LDADD = -lm \
 			${ELF_LIBS} \
 			${GCRYPT_LIBS} \
 			${NETTLE_LIBS} \
+			${GNUTLS_LIBS} \
 			${PCRE2_LIBS} \
 			${POSIX_ACL_LIBS} \
 			${PTHREAD_LIBS} \
@@ -109,11 +111,13 @@ check_aide_CFLAGS	= -I$(top_srcdir)/include \
 				$(CHECK_CFLAGS) \
 				${GCRYPT_CFLAGS} \
 				${NETTLE_CFLAGS} \
+				${GNUTLS_CFLAGS} \
 				${PCRE2_CFLAGS}
 check_aide_LDADD	= -lm \
 				$(CHECK_LIBS) \
 				${GCRYPT_LIBS} \
 				${NETTLE_LIBS} \
+				${GNUTLS_LIBS} \
 				${PCRE2_LIBS}
 endif # HAVE_CHECK
 

--- a/README
+++ b/README
@@ -126,8 +126,7 @@
        o  GNU make.
        o  pkg-config
        o  PCRE2 library (libpcre2-8, library with 8-bit code unit support)
-       o  libnettle or libgcrypt
-
+       o  libnettle, gnutls or libgcrypt
        o  libcheck (optional, needed for 'make check', license: LGPL-2.1)
 
     Note:

--- a/configure.ac
+++ b/configure.ac
@@ -344,6 +344,10 @@ AC_MSG_CHECKING(for Nettle)
 AC_ARG_WITH([nettle], AS_HELP_STRING([--with-nettle], [use Nettle crypto library (default: check)]), [with_nettle=$withval], [with_nettle=check])
 AC_MSG_RESULT([$with_nettle])
 
+AC_MSG_CHECKING(for GnuTLS)
+AC_ARG_WITH([gnutls], AS_HELP_STRING([--with-gnutls], [use GnuTLS library (default: check)]), [with_gnutls=$withval], [with_gnutls=check])
+AC_MSG_RESULT([$with_gnutls])
+
 AC_MSG_CHECKING(for GNU crypto library)
 AC_ARG_WITH([gcrypt], AS_HELP_STRING([--with-gcrypt], [use GNU crypto library (default: check)]), [with_gcrypt=$withval], [with_gcrypt=check])
 AC_MSG_RESULT([$with_gcrypt])
@@ -356,13 +360,25 @@ AIDE_PKG_CHECK_MODULES_OPTIONAL(gcrypt, GCRYPT, libgcrypt)
 AS_IF([test x"$with_nettle" != xno && test x"$with_gcrypt" != xno], [
     AC_MSG_ERROR([Using gcrypt together with Nettle makes no sense. To disable nettle use --without-nettle])
 ])
-AS_IF([test x"$with_nettle" = xno && test x"$with_gcrypt" = xno], [
-    AC_MSG_ERROR([AIDE requires nettle or libcrypt for hashsum calculation])
+AIDE_PKG_CHECK_MODULES_OPTIONAL(gnutls, GNUTLS, gnutls)
+AS_IF([test x"$with_nettle" != xno && test x"$with_gcrypt" != xno], [
+    AC_MSG_ERROR([Using gcrypt together with nettle makes no sense. To disable nettle use --without-nettle])
+])
+AS_IF([test x"$with_nettle" != xno && test x"$with_gnutls" != xno], [
+    AC_MSG_ERROR([Using gnutls together with nettle makes no sense. To disable nettle use --without-nettle])
+])
+AS_IF([test x"$with_gcrypt" != xno && test x"$with_gnutls" != xno], [
+    AC_MSG_ERROR([Using gnutls together with gcrypt makes no sense. To disable gcrypt use --without-gcrypt])
+])
+AS_IF([test x"$with_nettle" = xno && test x"$with_gcrypt" = xno && test x"$with_gnutls" == xno], [
+    AC_MSG_ERROR([AIDE requires nettle, gnutls or libcrypt for hashsum calculation])
 ])
 compoptionstring="${compoptionstring}use Nettle crypto library: $with_nettle\\n"
 AM_CONDITIONAL(HAVE_NETTLE, [test "x$NETTLE_LIBS" != "x"])
 compoptionstring="${compoptionstring}use GNU crypto library: $with_gcrypt\\n"
 AM_CONDITIONAL(HAVE_GCRYPT, [test "x$GCRYPT_LIBS" != "x"])
+compoptionstring="${compoptionstring}use GnuTLS: $with_gnutls\\n"
+AM_CONDITIONAL(HAVE_GNUTLS, [test "x$GNUTLS_LIBS" != "x"])
 
 AIDE_PKG_CHECK(audit, Linux Auditing Framework, no, AUDIT, audit)
 

--- a/include/md.h
+++ b/include/md.h
@@ -35,6 +35,10 @@
 #ifdef WITH_GCRYPT
 #include <gcrypt.h>
 #endif
+#ifdef WITH_GNUTLS
+#include <gnutls/gnutls.h>
+#include <gnutls/crypto.h>
+#endif
 #include <sys/types.h>
 #include "attributes.h"
 #include "hashsum.h"
@@ -78,6 +82,10 @@ typedef struct md_container {
 
 #ifdef WITH_GCRYPT
   gcry_md_hd_t mdh;
+#endif
+
+#ifdef WITH_GNUTLS
+  gnutls_hash_hd_t gnutls_mdh[num_hashes];
 #endif
 
 } md_container;

--- a/src/hashsum.c
+++ b/src/hashsum.c
@@ -30,6 +30,9 @@
 #include <gcrypt.h>
 #define NEED_LIBGCRYPT_VERSION "1.8.0"
 #endif
+#ifdef WITH_GNUTLS
+#include <gnutls/gnutls.h>
+#endif
 
 hashsum_t hashsums[] = {
     { attr_md5,             16 },
@@ -95,6 +98,27 @@ int algorithms[] = { /* order must match hashsums array */
 };
 #endif
 
+#ifdef WITH_GNUTLS
+int algorithms[] = { /* order must match hashsums array */
+  GNUTLS_DIG_MD5,
+  GNUTLS_DIG_SHA1,
+  GNUTLS_DIG_SHA256,
+  GNUTLS_DIG_SHA512,
+  GNUTLS_DIG_RMD160,
+  -1, /* TIGER is not available */
+  -1, /* CRC32 is not available */
+  -1, /* CRC32B is not available */
+  -1, /* GCRY_MD_HAVAL is not available */
+  -1, /* WHIRLPOOL is not available */
+  -1, /* GNUTLS_DIG_GOSTR_94 gives different results than Gcrypt */
+  GNUTLS_DIG_STREEBOG_256,
+  GNUTLS_DIG_STREEBOG_512,
+  -1, /* SHA512_256 is not natively implemented */
+  GNUTLS_DIG_SHA3_256,
+  GNUTLS_DIG_SHA3_512,
+};
+
+#endif
 void init_hashsum_lib(void) {
 #ifdef WITH_GCRYPT
   if(!gcry_check_version(NEED_LIBGCRYPT_VERSION)) {

--- a/src/md.c
+++ b/src/md.c
@@ -72,6 +72,10 @@ nettle_fucntions_t nettle_functions[] = {  /* order must match hashsums array */
     { (nettle_hash_init_func*) sha3_512_init, (nettle_hash_update_func*) sha3_512_update, (nettle_hash_digest_func*) sha3_512_digest },
 };
 #endif
+#ifdef WITH_GNUTLS
+#include <gnutls/gnutls.h>
+#include <gnutls/crypto.h>
+#endif
 
 /*
   Initialise md_container according its todo_attr field
@@ -116,6 +120,22 @@ int init_md(struct md_container* md, const char *filename) {
             }
   }
 #endif
+#ifdef WITH_GNUTLS
+   for (HASHSUM i = 0 ; i < num_hashes ; ++i) {
+        DB_ATTR_TYPE h = ATTR(hashsums[i].attribute);
+            if (h&md->todo_attr) {
+                if(gnutls_hash_init(&(md->gnutls_mdh[i]),algorithms[i])>=0){
+                    md->calc_attr|=h;
+                } else {
+                    log_msg(LOG_LEVEL_WARNING,"%s: gnutls_hash_init (%s) failed for '%s'", filename, attributes[hashsums[i].attribute].db_name, filename);
+                    md->todo_attr&=~h;
+                    md->gnutls_mdh[i] = NULL;
+                }
+            } else {
+                md->gnutls_mdh[i] = NULL;
+            }
+  }
+#endif
   char *str;
   log_msg(LOG_LEVEL_DEBUG, "%s> initialized md_container: %s (%p)", filename, str = diff_attributes(0, md->calc_attr), (void*) md);
   free(str);
@@ -146,6 +166,13 @@ int update_md(struct md_container* md,void* data,ssize_t size) {
 #endif
 #ifdef WITH_GCRYPT
 	gcry_md_write(md->mdh, data, size);
+#endif
+#ifdef WITH_GNUTLS
+  for (HASHSUM i = 0 ; i < num_hashes ; ++i) {
+      if(md->gnutls_mdh[i] != NULL){
+          gnutls_hash(md->gnutls_mdh[i], data, size);
+      }
+  }
 #endif
   return RETOK;
 }
@@ -186,6 +213,14 @@ int close_md(struct md_container* md, md_hashsums * hs, const char *filename) {
       }
   }
 #endif
+#ifdef WITH_GNUTLS
+  for (HASHSUM i = 0 ; i < num_hashes ; ++i) {
+      if(md->gnutls_mdh[i] != NULL){
+          gnutls_hash_deinit(md->gnutls_mdh[i], hs?hs->hashsums[i]:NULL);
+          md->gnutls_mdh[i] = NULL;
+      }
+  }
+#endif /* WITH_MHASH */
   if (hs) {
       hs->attrs = md->calc_attr;
   }


### PR DESCRIPTION
This is follow-up from #164. The decision was to go forward with nettle in 8ef6931719315a5f44cf6be11ccf73435822e2fe instead of GnuTLS under the assumption the GnuGLS does not have SHA3 hashes.

This is rebased patches on top of current master adding the SHA3 hashes still open for consideration.

Note, that Nettle is breaking ABI from time to time [1], while GnuTLS is trying to be more stable [2], which is a reason a long-term support distribution would choose one over the other (even though GnuTLS is using Nettle internally).

 - [1] https://abi-laboratory.pro/index.php?view=timeline&l=nettle
 - [2] https://abi-laboratory.pro/index.php?view=timeline&l=gnutls