### PR TITLE
Remove deprecated hashsums from default database_attrs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-02-21 yixiangzhike <yixiangzhike007@163.com>
+	* Fix some issues with libgcrypt
+	  - should call init_hashsum_lib before print_version
+	  - hashsums crc32,tiger,whirlpool are still supported by libgcrypt
+
 2025-02-20 yixiangzhike <yixiangzhike007@163.com>
 	* Remove deprecated hashsums from default config option database_attrs
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2025-02-20 yixiangzhike <yixiangzhike007@163.com>
+	* Remove deprecated hashsums from default config option database_attrs
+
 2025-01-13 Hannes von Haugwitz <hannes@vonhaugwitz.com>
 	* Fix calculation of duration
 

--- a/src/aide.c
+++ b/src/aide.c
@@ -489,7 +489,7 @@ static void setdefaults_before_config(void)
   conf->database_new.db_line = NULL;
   conf->database_new.flags = DB_FLAG_NONE;
 
-  conf->db_attrs = get_hashes(false);
+  conf->db_attrs = get_hashes(false)&~DEPRECATED_HASHES;
   
 #ifdef WITH_ZLIB
   conf->gzip_dbout=0;

--- a/src/aide.c
+++ b/src/aide.c
@@ -634,6 +634,7 @@ int main(int argc,char**argv)
   umask(0177);
 
   init_sighandler();
+  init_hashsum_lib();
 
   setdefaults_before_config();
 
@@ -668,8 +669,6 @@ int main(int argc,char**argv)
           }
       }
   }
-
-  init_hashsum_lib();
 
   /* get hostname */
   conf->hostname = checked_malloc(sizeof(char) * MAXHOSTNAMELEN + 1);

--- a/src/hashsum.c
+++ b/src/hashsum.c
@@ -51,7 +51,11 @@ hashsum_t hashsums[] = {
 };
 
 DB_ATTR_TYPE DEPRECATED_HASHES = ATTR(attr_md5)|ATTR(attr_sha1)|ATTR(attr_rmd160)|ATTR(attr_gostr3411_94);
+#ifdef WITH_NETTLE
 DB_ATTR_TYPE UNSUPPORTED_HASHES = ATTR(attr_crc32)|ATTR(attr_crc32b)|ATTR(attr_haval)|ATTR(attr_tiger)|ATTR(attr_whirlpool);
+#else
+DB_ATTR_TYPE UNSUPPORTED_HASHES = ATTR(attr_crc32b)|ATTR(attr_haval);
+#endif
 
 #ifdef WITH_NETTLE
 int algorithms[] = { /* order must match hashsums array */


### PR DESCRIPTION
The H default group is the default value for the config option database_attrs. 
So it should remove deprecated hashsums from default database_attrs also.