### PR TITLE
Remove deprecated hashsums from default database_attrs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2025-02-22 yixiangzhike <yixiangzhike007@163.com>
+	* Remove deprecated hashsums from default config option database_attrs
+
 2025-01-13 Hannes von Haugwitz <hannes@vonhaugwitz.com>
 	* Fix calculation of duration
 

--- a/src/aide.c
+++ b/src/aide.c
@@ -489,8 +489,6 @@ static void setdefaults_before_config(void)
   conf->database_new.db_line = NULL;
   conf->database_new.flags = DB_FLAG_NONE;
 
-  conf->db_attrs = get_hashes(false);
-  
 #ifdef WITH_ZLIB
   conf->gzip_dbout=0;
 #endif
@@ -558,6 +556,8 @@ static void setdefaults_before_config(void)
   do_groupdef("H",get_hashes(false)&~DEPRECATED_HASHES);
   do_groupdef("X",X);
   do_groupdef("E",0);
+
+  conf->db_attrs = get_groupval("H");
 
 }
 


### PR DESCRIPTION
The H default group is the default value for the config option database_attrs as "man aide.conf" says. 
So it should remove deprecated hashsums from default database_attrs also.